### PR TITLE
Fix issue with hidden transitive dependencies, update deps/plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,10 @@ under the License.
         <mavenVersion>3.8.1</mavenVersion>
         <doxiaVersion>1.4</doxiaVersion>
         <pluginTestingVersion>2.1</pluginTestingVersion>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <commons-lang.version>2.6</commons-lang.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-        <maven-dependency-tree.version>3.0.1</maven-dependency-tree.version>
+        <maven-dependency-tree.version>3.3.0</maven-dependency-tree.version>
         <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
         <maven-common-artifact-filters.version>3.0.1</maven-common-artifact-filters.version>
     </properties>
@@ -82,21 +81,25 @@ under the License.
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${mavenVersion}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
             <version>${mavenVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${mavenVersion}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${mavenVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commons-lang.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
@@ -123,8 +126,16 @@ under the License.
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.14.0</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.5</version>
+                    <version>3.15.1</version>
+                    <configuration>
+                        <goalPrefix>alignment-reporter</goalPrefix>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>default-descriptor</id>
@@ -141,5 +152,4 @@ under the License.
             </plugins>
         </pluginManagement>
     </build>
-
 </project>

--- a/src/main/java/com/github/k_wall/AlignmentReporterMojo.java
+++ b/src/main/java/com/github/k_wall/AlignmentReporterMojo.java
@@ -18,43 +18,19 @@ package com.github.k_wall;/*
  */
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 
-@SuppressWarnings("unused")
 @Mojo(name = "report", requiresDependencyCollection = ResolutionScope.TEST, threadSafe = true)
 public class AlignmentReporterMojo extends AbstractAlignmentReporterMojo
 {
     @Override
-    protected Set<DependencyNode> getDirectDependencies(final ArtifactFilter artifactFilter)
-            throws DependencyGraphBuilderException
+    protected Set<DependencyNode> getDirectDependencies(final ArtifactFilter artifactFilter) throws MojoExecutionException
     {
-        Set<Artifact> reactorArtifacts =
-                reactorProjects.stream().map(MavenProject::getArtifact).collect(Collectors.toSet());
-
-        Set<Artifact> artifacts = getProject().getDependencyArtifacts()
-                                              .stream()
-                                              .filter(a -> !reactorArtifacts.contains(a))
-                                              .collect(Collectors.toSet());
-
-        ProjectBuildingRequest buildingRequest =
-                new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-        buildingRequest.setProject(getProject());
-
-        DependencyNode rootNode =
-                dependencyGraphBuilder.buildDependencyGraph(buildingRequest, artifactFilter, reactorProjects);
-
-        return rootNode.getChildren().stream()
-                       .filter(node -> artifacts.contains(node.getArtifact()))
-                       .collect(Collectors.toSet());
+        return getDirectDependencies(getProject(), artifactFilter);
     }
 }


### PR DESCRIPTION
- Bump several dependencies/plugins
- Update project to Java 11
- Remove commons-lang no longer needed with Java 11
- Adjust formatting of `Artifact`s in the report use `Artifact#toString` which includes additional information such as scope and classifier (if applicable).
- Modify how project dependencies are retrieved, especially when `test` scope artifacts are not being considered.

Regarding the final point, there are cases where a test and a non-test dependency may conflict and the Maven dependency graph only lists that dependency as a child of the test-scoped dependency. Since that test-scope node is skipped due to filtering, the unaligned dependency is invisible to the scanner. By introducing a proxy/shim project created on-the-fly, the dependency graph will be built as if a project is itself a dependency. This has the effect of dropping all the test-scoped deps and building the tree as expected, including the dependency nodes that otherwise would have been omitted due to conflict.